### PR TITLE
changed query GetLaunches to the correct version

### DIFF
--- a/docs/source/tutorial/resolvers.md
+++ b/docs/source/tutorial/resolvers.md
@@ -91,10 +91,12 @@ Start by copying the GraphQL query below and pasting it in the left side of the 
 ```graphql
 query GetLaunches {
   launches {
-    id
-    mission {
-      name
-    }
+    launches {
+      id
+      mission {
+        name
+      }
+    } 
   }
 }
 ```


### PR DESCRIPTION
The original getLaunches query returns an error, potentially because it returned launchConnection but it doesnot contain fields id, mission. We need to query inside the launches array of launchConnection since only launch type has fields id, mission.